### PR TITLE
Update workflow to allow multiple emails

### DIFF
--- a/.github/workflows/email-agent.yml
+++ b/.github/workflows/email-agent.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      USER_EMAILS: ${{ secrets.USER_EMAILS }}
+      TOKEN_DAWSONPOWELL07_GMAIL_COM_JSON: ${{ secrets.TOKEN_DAWSONPOWELL07_GMAIL_COM_JSON }}
+      TOKEN_DQPOWEL_CLEMSON_EDU_JSON: ${{ secrets.TOKEN_DQPOWEL_CLEMSON_EDU_JSON }}
     
     steps:
     - name: Checkout code
@@ -32,13 +35,23 @@ jobs:
         
     - name: Create token files
       run: |
-        echo '${{ secrets.TOKEN1_JSON }}' > token1.json
-        echo '${{ secrets.TOKEN2_JSON }}' > token2.json
+        IFS=',' read -ra EMAILS <<< "$USER_EMAILS"
+        for email in "${EMAILS[@]}"; do
+          safe=$(echo "$email" | tr '@.' '_')
+          var="TOKEN_${safe}_JSON"
+          token=$(printenv "$var")
+          if [ -z "$token" ]; then
+            echo "Missing token for $email ($var)" >&2
+            exit 1
+          fi
+          echo "$token" > "token_${email}.json"
+        done
         
     - name: Debug environment
       run: |
         echo "Checking environment variables:"
         echo "OPENAI_API_KEY is set: ${{ env.OPENAI_API_KEY != '' }}"
+        echo "USER_EMAILS: $USER_EMAILS"
         
     - name: Run email agent
       run: |

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ To use Gmail features, you need to set up authentication:
 
 ### Usage
 
-Run the graph for a specific user email:
+Set the `USER_EMAILS` environment variable with a comma‑separated list of email addresses and run the graph:
 
 ```bash
+export USER_EMAILS="user1@example.com,user2@example.com"
 python run_graph.py
 ```
 
-The `State` object now requires a `user_email` value. Credentials for that user are loaded from `token_<email>.json` and cached for future tool calls.
+If `USER_EMAILS` is not set, the default list inside `run_graph.py` is used. The `State` object requires a `user_email` value, and credentials for each user are loaded from `token_<email>.json`.

--- a/graph.py
+++ b/graph.py
@@ -3,7 +3,6 @@ from state import State
 from nodes.classifier import classifier_agent
 from nodes.summarizer import summarizer_agent
 from nodes.authenticator import load_auth
-from utils.print import pretty_print_messages
 
 
 graph_builder = StateGraph(State)

--- a/run_graph.py
+++ b/run_graph.py
@@ -41,10 +41,16 @@ def main() -> None:
 
     if not os.getenv("OPENAI_API_KEY"):
         print("❌ Error: OPENAI_API_KEY environment variable not set")
-        print("Make sure to set the OPENAI_API_KEY environment variable or add it to your .env file")
+        print(
+            "Make sure to set the OPENAI_API_KEY environment variable or add it to your .env file"
+        )
         return
 
-    users = ["dawsonpowell07@gmail.com", "dqpowel@clemson.edu"]
+    users_env = os.getenv("USER_EMAILS")
+    if users_env:
+        users = [e.strip() for e in users_env.split(",") if e.strip()]
+    else:
+        users = ["dawsonpowell07@gmail.com", "dqpowel@clemson.edu"]
     results = []
     for email in users:
         success = run_for_user(email)


### PR DESCRIPTION
## Summary
- remove unused import in `graph.py`
- allow specifying emails via `USER_EMAILS` env var in `run_graph.py`
- document how to set `USER_EMAILS` in the README
- update GitHub Actions workflow to use the new variable and create token files dynamically

## Testing
- `ruff format graph.py run_graph.py`
- `ruff check graph.py run_graph.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d4c93b23883338e11e2238b648763