### PR TITLE
Add Google OAuth auth verification and session storage

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,98 @@
+"""Authentication utilities for verifying Google OAuth tokens."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import Iterator, Optional
+
+from fastapi import Depends, HTTPException
+from google.auth.transport import requests
+from google.oauth2 import id_token
+from sqlmodel import SQLModel, Field, Session, create_engine, select
+
+from .schemas import AgentRequest
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./auth.db")
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+
+
+class User(SQLModel, table=True):
+    """Database model representing an authenticated user."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    email: str
+    google_sub: str
+    token_expiry: datetime
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+def create_db_and_tables() -> None:
+    """Create database tables."""
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Iterator[Session]:
+    """Yield a SQLModel session."""
+    with Session(engine) as session:
+        yield session
+
+
+logger = logging.getLogger(__name__)
+
+
+def verify_token(token_info: str, session: Session) -> User:
+    """Validate the provided OAuth token and persist the user.
+
+    Args:
+        token_info: Raw OAuth token JSON string from the client.
+        session: Database session.
+
+    Returns:
+        A ``User`` instance representing the authenticated user.
+
+    Raises:
+        HTTPException: If the token is missing or invalid.
+    """
+    if not token_info:
+        raise HTTPException(status_code=401, detail="Missing token")
+
+    try:
+        info = json.loads(token_info)
+        raw_token = info.get("token") or info.get("id_token")
+        if raw_token is None:
+            raise ValueError("token field missing")
+        idinfo = id_token.verify_oauth2_token(
+            raw_token, requests.Request(), info.get("client_id")
+        )
+    except (
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:  # pragma: no cover - broad except for robustness
+        logger.exception("Token verification failed: %s", exc)
+        raise HTTPException(status_code=401, detail="Invalid token") from exc
+
+    email = idinfo.get("email")
+    sub = idinfo.get("sub")
+    expiry = datetime.fromtimestamp(idinfo.get("exp", 0))
+
+    user = session.exec(select(User).where(User.google_sub == sub)).first()
+    if user is None:
+        user = User(email=email, google_sub=sub, token_expiry=expiry)
+        session.add(user)
+    else:
+        user.email = email
+        user.token_expiry = expiry
+    session.commit()
+
+    logger.info("Authenticated user %s", email)
+    return user
+
+
+def get_current_user(
+    request: AgentRequest, session: Session = Depends(get_session)
+) -> User:
+    """FastAPI dependency that authenticates the request and returns the user."""
+    return verify_token(request.token_info, session)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,29 +1,47 @@
 from agent.graph import graph as agent_app
-from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
-from typing import Optional, List, Dict
+from agent.nodes.summarizer import summarizer_agent
+from fastapi import Depends, FastAPI, HTTPException
 import traceback
+
+from .auth import User, create_db_and_tables, get_current_user
+from .schemas import AgentRequest
 
 app = FastAPI()
 
-class AgentRequest(BaseModel):
-    # Email address for the current user
-    user_email: str
-    # Cached OAuth token information
-    token_info: Optional[str]
-    
+
+@app.on_event("startup")
+def on_startup() -> None:
+    """Initialize application resources."""
+    create_db_and_tables()
+
 
 @app.post("/label")
-async def label(request: AgentRequest):
+async def label(request: AgentRequest, user: User = Depends(get_current_user)):
     state = {
         "messages": [{"role": "user", "content": "classify my emails"}],
-        "user_email": request.user_email,
+        "user_email": user.email,
         "token_info": request.token_info,
     }
 
     try:
         result = await agent_app.ainvoke(state)
         return result  # or filter response keys
-    except Exception:
-        print(traceback.format_exc())  # good for debugging
+    except Exception:  # pragma: no cover - logged for debugging
+        print(traceback.format_exc())
+        raise HTTPException(status_code=500, detail="Agent processing failed")
+
+
+@app.post("/summarize")
+async def summarize(request: AgentRequest, user: User = Depends(get_current_user)):
+    state = {
+        "messages": [{"role": "user", "content": "summarize my emails"}],
+        "user_email": user.email,
+        "token_info": request.token_info,
+    }
+
+    try:
+        result = await summarizer_agent.ainvoke(state)
+        return result
+    except Exception:  # pragma: no cover - logged for debugging
+        print(traceback.format_exc())
         raise HTTPException(status_code=500, detail="Agent processing failed")

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class AgentRequest(BaseModel):
+    """Request payload for agent endpoints."""
+
+    user_email: str
+    token_info: Optional[str]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ google-auth-httplib2
 google-auth-oauthlib
 fastapi
 pydantic
+google-auth
+sqlmodel

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,36 @@
+import json
+import os
+
+from fastapi.testclient import TestClient
+from google.oauth2 import id_token
+from sqlmodel import SQLModel, Session, create_engine, select
+
+# configure in-memory database for tests
+os.environ["DATABASE_URL"] = "sqlite://"
+
+from backend.auth import User, verify_token  # noqa: E402
+from backend.main import app  # noqa: E402
+
+
+client = TestClient(app)
+
+
+def test_verify_token_creates_user(monkeypatch):
+    def fake_verify(token, request, audience=None):  # pragma: no cover - simple stub
+        return {"email": "user@example.com", "sub": "abc", "exp": 32503680000}
+
+    monkeypatch.setattr(id_token, "verify_oauth2_token", fake_verify)
+
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        token_info = json.dumps({"token": "t", "client_id": "c"})
+        user = verify_token(token_info, session)
+        assert user.email == "user@example.com"
+        db_user = session.exec(select(User)).first()
+        assert db_user is not None
+
+
+def test_label_requires_token():
+    response = client.post("/label", json={"user_email": "a", "token_info": None})
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- verify incoming Google OAuth tokens and persist session data using SQLModel
- expose `get_current_user` dependency to secure label and summarize endpoints
- add tests for authentication utility and endpoint auth checks

## Testing
- `ruff format`
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlmodel')*


------
https://chatgpt.com/codex/tasks/task_e_68921acbde4c833393ae919caf2ae358