### PR TITLE
Add user model and CRUD API for authentication

### DIFF
--- a/backend/api/auth/auth.py
+++ b/backend/api/auth/auth.py
@@ -16,22 +16,21 @@ GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
 
 @router.get("/login")
 async def login(request: Request):
-    redirect_uri = request.url_for('auth_callback')
+    redirect_uri = request.url_for("auth_callback")
     google_auth_url = f"https://accounts.google.com/o/oauth2/auth?client_id={GOOGLE_CLIENT_ID}&redirect_uri={redirect_uri}&response_type=code&scope=openid email profile"
 
     return RedirectResponse(url=google_auth_url)
-
 
 
 @router.get("/callback")
 async def auth_callback(code: str, request: Request):
     token_request_uri = "https://oauth2.googleapis.com/token"
     data = {
-        'code': code,
-        'client_id': GOOGLE_CLIENT_ID,
-        'client_secret': GOOGLE_CLIENT_SECRET,
-        'redirect_uri': request.url_for('auth_callback'),
-        'grant_type': 'authorization_code',
+        "code": code,
+        "client_id": GOOGLE_CLIENT_ID,
+        "client_secret": GOOGLE_CLIENT_SECRET,
+        "redirect_uri": request.url_for("auth_callback"),
+        "grant_type": "authorization_code",
     }
 
     async with httpx.AsyncClient() as client:
@@ -39,20 +38,22 @@ async def auth_callback(code: str, request: Request):
         response.raise_for_status()
         token_response = response.json()
 
-    id_token_value = token_response.get('id_token')
+    id_token_value = token_response.get("id_token")
     if not id_token_value:
         raise HTTPException(status_code=400, detail="Missing id_token in response.")
 
     try:
-        id_info = id_token.verify_oauth2_token(id_token_value, requests.Request(), GOOGLE_CLIENT_ID)
+        id_info = id_token.verify_oauth2_token(
+            id_token_value, requests.Request(), GOOGLE_CLIENT_ID
+        )
 
-        name = id_info.get('name')
-        request.session['user_name'] = name
+        name = id_info.get("name")
+        request.session["user_name"] = name
 
-        return RedirectResponse(url=request.url_for('welcome'))
+        return RedirectResponse(url=request.url_for("welcome"))
 
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Invalid id_token: {str(e)}")
 
-    except Exception as e:
+    except Exception:
         raise HTTPException(status_code=500, detail="Internal Server Error")

--- a/backend/api/auth/users.py
+++ b/backend/api/auth/users.py
@@ -1,0 +1,87 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import Response
+from sqlalchemy.orm import Session
+from backend.db import crud, models
+from backend.db.session import get_db
+from backend.schemas.users import UserCreate, UserRead, UserUpdate
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+def get_current_user(db: Session = Depends(get_db)) -> models.User:
+    """Retrieve the current authenticated user.
+
+    This is a placeholder implementation and should be replaced with a proper
+    authentication mechanism.
+    """
+    user = db.query(models.User).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+        )
+    return user
+
+
+@router.post("/", response_model=UserRead, status_code=status.HTTP_201_CREATED)
+def create_user(user: UserCreate, db: Session = Depends(get_db)) -> models.User:
+    if crud.get_user_by_email(db, user.email):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered"
+        )
+    return crud.create_user(db, user)
+
+
+@router.get("/{user_id}", response_model=UserRead)
+def read_user(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> models.User:
+    if current_user.id != user_id and current_user.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized"
+        )
+    db_user = crud.get_user_by_id(db, user_id)
+    if not db_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+    return db_user
+
+
+@router.put("/{user_id}", response_model=UserRead)
+def update_user(
+    user_id: int,
+    user_update: UserUpdate,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> models.User:
+    if current_user.id != user_id and current_user.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized"
+        )
+    db_user = crud.get_user_by_id(db, user_id)
+    if not db_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+    return crud.update_user(db, db_user, user_update)
+
+
+@router.delete("/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_user(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_user: models.User = Depends(get_current_user),
+) -> Response:
+    if current_user.id != user_id and current_user.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized"
+        )
+    db_user = crud.get_user_by_id(db, user_id)
+    if not db_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+    crud.delete_user(db, db_user)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/db/crud.py
+++ b/backend/db/crud.py
@@ -1,1 +1,38 @@
+from sqlalchemy.orm import Session
+from typing import Optional
+from . import models
+from backend.schemas.users import UserCreate, UserUpdate
 
+
+def create_user(db: Session, user: UserCreate) -> models.User:
+    """Create a new user."""
+    db_user = models.User(email=user.email, name=user.name, role=user.role)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+def get_user_by_email(db: Session, email: str) -> Optional[models.User]:
+    """Retrieve a user by email."""
+    return db.query(models.User).filter(models.User.email == email).first()
+
+
+def get_user_by_id(db: Session, user_id: int) -> Optional[models.User]:
+    """Retrieve a user by id."""
+    return db.query(models.User).filter(models.User.id == user_id).first()
+
+
+def update_user(db: Session, db_user: models.User, updates: UserUpdate) -> models.User:
+    """Update an existing user."""
+    for field, value in updates.model_dump(exclude_unset=True).items():
+        setattr(db_user, field, value)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+def delete_user(db: Session, db_user: models.User) -> None:
+    """Delete a user."""
+    db.delete(db_user)
+    db.commit()

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from sqlalchemy import Column, DateTime, Integer, String
+from .session import Base
+
+
+class User(Base):
+    """SQLAlchemy model for application users."""
+
+    __tablename__ = "users"
+
+    id: int = Column(Integer, primary_key=True, index=True)
+    email: str = Column(String, unique=True, index=True, nullable=False)
+    name: str = Column(String, nullable=False)
+    role: str = Column(String, default="user", nullable=False)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow)

--- a/backend/db/session.py
+++ b/backend/db/session.py
@@ -1,0 +1,24 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+from typing import Generator
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+
+if DATABASE_URL.startswith("sqlite"):
+    engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+else:
+    engine = create_engine(DATABASE_URL)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db() -> Generator:
+    """Yield a new database session."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/schemas/users.py
+++ b/backend/schemas/users.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from pydantic import BaseModel, EmailStr
+from typing import Optional
+
+
+class UserBase(BaseModel):
+    email: EmailStr
+    name: str
+    role: str = "user"
+
+
+class UserCreate(UserBase):
+    """Schema for creating users."""
+
+
+class UserRead(UserBase):
+    """Schema for reading users."""
+
+    id: int
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class UserUpdate(BaseModel):
+    """Schema for updating users."""
+
+    email: Optional[EmailStr] = None
+    name: Optional[str] = None
+    role: Optional[str] = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,10 @@ langsmith
 langchain-openai
 python-dotenv
 openai
-google-api-python-client 
-google-auth-httplib2 
+google-api-python-client
+google-auth-httplib2
 google-auth-oauthlib
 langgraph-cli[inmem]
 fastapi
 pydantic
+sqlalchemy

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,94 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.main import app
+from backend.db.session import Base, get_db
+from backend.db import models
+from backend.api.auth.users import get_current_user
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def override_get_current_user():
+    db = TestingSessionLocal()
+    try:
+        return db.query(models.User).first()
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+app.dependency_overrides[get_current_user] = override_get_current_user
+
+client = TestClient(app)
+
+
+def test_user_crud_flow():
+    response = client.post(
+        "/api/authentication/users/",
+        json={"email": "test@example.com", "name": "Test", "role": "user"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["email"] == "test@example.com"
+    user_id = data["id"]
+
+    response = client.get(f"/api/authentication/users/{user_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == user_id
+
+    response = client.put(
+        f"/api/authentication/users/{user_id}",
+        json={"name": "Updated"},
+    )
+    assert response.status_code == 200
+    assert response.json()["name"] == "Updated"
+
+    response = client.delete(f"/api/authentication/users/{user_id}")
+    assert response.status_code == 204
+
+    response = client.get(f"/api/authentication/users/{user_id}")
+    assert response.status_code == 404
+
+
+def test_unauthorized_access():
+    db = TestingSessionLocal()
+    user1 = models.User(email="a@example.com", name="A", role="user")
+    user2 = models.User(email="b@example.com", name="B", role="user")
+    db.add_all([user1, user2])
+    db.commit()
+    db.refresh(user1)
+    db.refresh(user2)
+    db.close()
+
+    def override_current_user_b():
+        db = TestingSessionLocal()
+        try:
+            return (
+                db.query(models.User)
+                .filter(models.User.email == "b@example.com")
+                .first()
+            )
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_current_user] = override_current_user_b
+    response = client.put(
+        f"/api/authentication/users/{user1.id}",
+        json={"name": "Hack"},
+    )
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- add SQLAlchemy user model, CRUD helpers, and Pydantic schemas
- expose user management API routes with access control
- integrate database session handling and router registration
- scaffold tests for CRUD flow

## Testing
- `ruff format`
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install sqlalchemy` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_689241eb383c8333b8a4b24bc3c2cfb7